### PR TITLE
Fix README import

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ beeminder-cli
 ## Using the API Client
 
 ```python
-from src.beeminder import BeeminderAPI
+from beeminder_client.beeminder import BeeminderAPI
 
 # Initialize client
 client = BeeminderAPI(api_key="your-api-key", default_user="username")


### PR DESCRIPTION
When you're importing it from outside the repo, you'll want to use the installed version as the basis for the import.